### PR TITLE
bugfix - fetch environment variables before declaring theme

### DIFF
--- a/src/components/Base.js
+++ b/src/components/Base.js
@@ -34,9 +34,9 @@ function ErrorFallBack({ error }) {
 const queryClient = new QueryClient();
 
 export default function Base({ children }) {
+  fetchEnvData();
   const theme = getTheme();
   const sections = getSectionsToShow();
-  fetchEnvData();
   useLayoutEffect(() => {
     injectFaviconByProject();
   }, []);


### PR DESCRIPTION
fix bug from last PR #2 
- retrieve environment variable before getting theme, which is dependent on the presence of environment variable, `REACT_APP_PROJECT_ID`,  in the newly created base component.