### PR TITLE
make report more print-friendly

### DIFF
--- a/src/components/BottomNav.js
+++ b/src/components/BottomNav.js
@@ -28,6 +28,7 @@ export default function BottomNav() {
   };
   const renderDrawer = () => (
     <Drawer
+      className="print-hidden"
       open={open}
       sx={{
         display: mediaDisplays,
@@ -66,6 +67,7 @@ export default function BottomNav() {
     <>
       {renderDrawer()}
       <Paper
+        className="print-hidden"
         sx={{
           position: "fixed",
           bottom: 0,

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -43,7 +43,7 @@ export default function Header(props) {
   const renderReturnButton = () => {
     if (!returnURL) return null;
     return (
-      <Box sx={{ flex: 1, textAlign: "right", marginTop: 1, marginBotton: 1 }}>
+      <Box className="print-hidden" sx={{ flex: 1, textAlign: "right", marginTop: 1, marginBotton: 1 }}>
         <Button
           color="primary"
           href={returnURL + "/clear_session"}

--- a/src/components/MedicalHistory.js
+++ b/src/components/MedicalHistory.js
@@ -20,19 +20,22 @@ export default function MedicalHistory(props) {
     const goodData = data.filter(
       (item) => item.code && item.code.coding && item.code.coding.length > 0
     );
-    return goodData.map((item, index) => {
-      item.id = item.id + "_" + index;
-      item.condition = item.code.coding[0].display;
-      item.onsetDateTime = getCorrectedISODate(item.onsetDateTime);
-      item.recordedDate = getCorrectedISODate(item.recordedDate);
-      return item;
-    }).sort((a, b) => {
-      return (
-        new Date(b.onsetDateTime).getTime() -
-        new Date(a.onsetDateTime).getTime()
-      );
-    });
+    return goodData
+      .map((item, index) => {
+        item.id = item.id + "_" + index;
+        item.condition = item.code.coding[0].display;
+        item.onsetDateTime = getCorrectedISODate(item.onsetDateTime);
+        item.recordedDate = getCorrectedISODate(item.recordedDate);
+        return item;
+      })
+      .sort((a, b) => {
+        return (
+          new Date(b.onsetDateTime).getTime() -
+          new Date(a.onsetDateTime).getTime()
+        );
+      });
   };
+  const results = getData(data);
   const columns = [
     {
       title: "ID",
@@ -52,23 +55,48 @@ export default function MedicalHistory(props) {
       field: "recordedDate",
     },
   ];
-  const results = getData(data);
+  const renderPrintView = (data) => {
+    const displayColumns = columns.filter((column) => !column.hidden);
+    return (
+      <table>
+        <thead>
+          {displayColumns.map((column) => (
+            <th>{column.title}</th>
+          ))}
+        </thead>
+        <tbody>
+          {data.map((result) => {
+            return <tr>{displayColumns.map(column => <td>{result[column.field]}</td>)}</tr>;
+          })}
+        </tbody>
+      </table>
+    );
+  };
   if (!results || !results.length)
-    return <Alert severity="warning" className="condition-no-data">No recorded condition</Alert>;
+    return (
+      <Alert severity="warning" className="condition-no-data">
+        No recorded condition
+      </Alert>
+    );
   return (
-    <MaterialTable
-      columns={columns}
-      data={getData(data)}
-      options={{
-        search: false,
-        showTitle: false,
-        toolbar: false,
-        padding: "dense",
-        headerStyle: {
-          backgroundColor: bgColor
-        }
-      }}
-    ></MaterialTable>
+    <>
+      <div className="print-hidden">
+        <MaterialTable
+          columns={columns}
+          data={getData(data)}
+          options={{
+            search: false,
+            showTitle: false,
+            toolbar: false,
+            padding: "dense",
+            headerStyle: {
+              backgroundColor: bgColor,
+            },
+          }}
+        ></MaterialTable>
+      </div>
+      <div className="print-only">{renderPrintView(results)}</div>
+    </>
   );
 }
 

--- a/src/components/QuestionnaireSelector.js
+++ b/src/components/QuestionnaireSelector.js
@@ -72,6 +72,7 @@ export default function QuestionnaireSelector(props) {
           paddingRight: 1,
         }}
         margin="dense"
+        className="print-hidden"
       >
         <Select
           id="qSelector"

--- a/src/components/ScoringSummary.js
+++ b/src/components/ScoringSummary.js
@@ -178,7 +178,7 @@ export default function ScoringSummary(props) {
   };
 
   return (
-    <Paper sx={{ minWidth: "50%" }}>
+    <Paper className="scoring-summary-container" sx={{ minWidth: "50%" }}>
       {renderTitle()}
       {renderSummary()}
     </Paper>

--- a/src/components/SideNav.js
+++ b/src/components/SideNav.js
@@ -89,6 +89,7 @@ export default function SideNav (props) {
     return (
       <Drawer
         variant="permanent"
+        className="print-hidden"
         open={open}
         sx={{
           display: {

--- a/src/components/Summaries.js
+++ b/src/components/Summaries.js
@@ -531,6 +531,7 @@ export default function Summaries() {
   };
 
   const renderPrintButton = () => {
+    if (error) return null;
     return (
       <Button
         className="print-hidden"

--- a/src/components/Summaries.js
+++ b/src/components/Summaries.js
@@ -41,7 +41,7 @@ import QuestionnaireSelector from "./QuestionnaireSelector";
 import ScoringSummary from "./ScoringSummary";
 import Summary from "./Summary";
 import Version from "./Version";
-import { Typography } from "@mui/material";
+import { Button, Typography } from "@mui/material";
 import qConfig from "../config/questionnaire_config";
 import {
   DEFAULT_DRAWER_WIDTH,
@@ -275,7 +275,7 @@ export default function Summaries() {
 
   const renderNavButton = () => (
     <FabRef
-      className={"hide"}
+      className={"hide print-hidden"}
       ref={fabRef}
       color="primary"
       aria-label="add"
@@ -303,7 +303,10 @@ export default function Summaries() {
     return sectionsToShow.map((section) => {
       const sectionId = section.id.toLowerCase();
       return (
-        <Box key={"accordion_wrapper_"+section.id}>
+        <Box
+          key={"accordion_wrapper_" + section.id}
+          className="accordion-wrapper"
+        >
           <Box
             id={`anchor_${section.id}`}
             key={`anchor_${section.id}`}
@@ -322,7 +325,12 @@ export default function Summaries() {
             }
           >
             <AccordionSummary
-              expandIcon={<ExpandMoreIcon sx={{ color: "#FFF" }} />}
+              expandIcon={
+                <ExpandMoreIcon
+                  sx={{ color: "#FFF" }}
+                  className="print-hidden"
+                />
+              }
               aria-controls="panel1a-content"
               id={`accordion_${section.id}`}
               sx={{
@@ -375,7 +383,7 @@ export default function Summaries() {
           : null;
       if (!dataObject) return null;
       return (
-        <Box key={`summary_container_${index}`}>
+        <Box className="summary-container" key={`summary_container_${index}`}>
           <Summary
             questionnaireId={questionnaireId}
             data={summaryData.data[questionnaireId]}
@@ -383,6 +391,7 @@ export default function Summaries() {
           ></Summary>
           {index !== questionnaireList.length - 1 && (
             <Divider
+              className="print-hidden"
               key={`questionnaire_divider_${index}`}
               sx={{ borderWidth: "2px", marginBottom: 2 }}
               light
@@ -396,6 +405,7 @@ export default function Summaries() {
   const renderQuestionnaireSelector = () => {
     return (
       <BoxRef
+        className="print-hidden"
         ref={selectorRef}
         style={{
           opacity: isReady() ? 1 : 0.4,
@@ -520,6 +530,18 @@ export default function Summaries() {
     );
   };
 
+  const renderPrintButton = () => {
+    return (
+      <Button
+        className="print-hidden"
+        variant="outlined"
+        onClick={() => window.print()}
+      >
+        Print
+      </Button>
+    );
+  };
+
   useEffect(() => {
     window.addEventListener("scroll", handleFab);
     return () => {
@@ -547,7 +569,10 @@ export default function Summaries() {
             }}
           >
             <section>
-              <PatientInfo patient={patient}></PatientInfo>
+              <Stack direction="row" justifyContent="space-between" spacing={2}>
+                <PatientInfo patient={patient}></PatientInfo>
+                {renderPrintButton()}
+              </Stack>
               {error && (
                 <Box sx={{ marginTop: 1 }}>
                   <ErrorComponent message={error}></ErrorComponent>
@@ -557,6 +582,7 @@ export default function Summaries() {
                 <>
                   <>
                     <Stack
+                      className="selector-stats-wrapper"
                       direction={{ xs: "column", sm: "column", md: "row" }}
                       spacing={2}
                       sx={{

--- a/src/components/Summary.js
+++ b/src/components/Summary.js
@@ -90,6 +90,7 @@ export default function Summary(props) {
       component="h3"
       color="accent"
       sx={{ marginBottom: 2 }}
+      className="questionnaire-title"
     >
       {getQuestionnaireTitle()}
     </Typography>

--- a/src/components/TimeoutModal.js
+++ b/src/components/TimeoutModal.js
@@ -31,7 +31,6 @@ export default function TimeoutModal() {
   return (
     <>
       <Modal
-        hideBackdrop
         open={open}
         onClose={handleClose}
         aria-labelledby="child-modal-title"

--- a/src/style/App.scss
+++ b/src/style/App.scss
@@ -1,9 +1,13 @@
 $chart-background-color: #f4f6f6;
 $muted-text-color: #777;
+$border-color: #ececec;
 $app-background-color: #dad7da;
-$summary-container-background-color: #FFF;
+$summary-container-background-color: #fff;
+$default-print-background-color: #FFF;
+$default-print-color: #444;
 
-html, body {
+html,
+body {
   height: 100%;
 }
 #root {
@@ -18,6 +22,9 @@ body {
 main {
   background-color: $app-background-color;
   min-height: 100%;
+}
+.print-only {
+  display: none;
 }
 .summaries {
   padding: 16px 24px;
@@ -65,5 +72,81 @@ p {
 @media (min-width: 600px) {
   .header-logo {
     width: 180px;
+  }
+}
+@media print {
+  @page {
+    margin: 5mm 5mm 5mm 5mm;
+  }
+  .print-hidden {
+    display: none !important;
+  }
+  .print-only {
+    display: block;
+  }
+  .selector-stats-wrapper {
+    background-color: $default-print-background-color !important;
+    margin-top: 8px !important;
+    margin-bottom: 16px !important;
+    padding: 0 !important;
+  }
+  header {
+    background-color: $default-print-background-color !important;
+    box-shadow: none !important;
+  }
+  .scoring-summary-container {
+    padding: 0 !important;
+  }
+  .chart__container {
+    width: 100% !important;
+    background-color: $default-print-background-color !important;
+  }
+  .summary-container:not(:first-of-type) {
+    page-break-inside: avoid;
+  }
+  .questionnaire-title {
+    page-break-after: avoid;
+    width: 100%;
+    border-bottom: 1px solid $default-print-color !important;
+  }
+  .accordion-wrapper {
+    page-break-inside: avoid;
+  }
+  .MuiToolbar-root {
+    background-color: $default-print-background-color !important;
+    box-shadow: none !important;
+  }
+  .MuiTablePagination-toolbar {
+    display: none !important;
+  }
+  .MuiAccordion-root {
+    box-shadow: none !important;
+    table {
+      display: table;
+      width: 100%;
+      border-collapse: collapse;
+      border-spacing: 0;
+      th, td {
+        border: 1px solid $border-color;
+        text-align: center;
+        background-color: $summary-container-background-color !important;
+        color: $default-print-color !important;
+        padding: 4px;
+      }
+      td:empty {
+        border-bottom: 0 !important;
+      }
+    }
+  }
+  .MuiAccordionDetails-root {
+    padding: 8px 0 !important;
+  }
+  .MuiTab-root.Mui-selected {
+    color: #444 !important;
+    padding-bottom: 0 !important;
+    border-bottom: 2px solid $border-color;
+  }
+  .MuiTabs-indicator {
+    background-color: transparent !important;
   }
 }


### PR DESCRIPTION
address: https://www.pivotaltracker.com/story/show/184027974
made changes to allow patient summary report to be more print friendly.

Changes includes:
- added print button to allow printing. See sample screenshot of the added button:

![Screen Shot 2022-12-19 at 11 41 28 AM](https://user-images.githubusercontent.com/12942714/208507377-05bc6b75-ee7f-438e-9939-6de6da1a2ff4.png)

- added css class, `print-hidden`, to allow hiding of elements that shouldn't appear in print, e.g. print button, side navigation, bottom navigation
- added helper css classes to allow more user friendly rendering of elements
- added code to render print only pertinent medical history conditions (data is paginated in non-print view)

See sample generated print of report:
[Patient Summary.pdf](https://github.com/uwcirg/patient-summary/files/10262267/Patient.Summary.pdf)
