### PR TITLE
Feature/responses refinements

### DIFF
--- a/src/components/Responses.js
+++ b/src/components/Responses.js
@@ -65,7 +65,6 @@ export default function Responses(props) {
       filterComponent: ({ columnDef, onFilterChanged }) => (
         <Input
           className="print-hidden"
-          arialLabel="Filter"
           placeholder="Filter"
           startAdornment={
             <InputAdornment position="start">
@@ -211,7 +210,7 @@ export default function Responses(props) {
                   }}
                 ></TableCell>
                 {arrDates.map((item, index) => (
-                  <TableCell key={`score_cell_${index}`}>
+                  <TableCell key={`answer_cell_${index}`}>
                     {getMatchedAnswerByLinkIdDateId(row.id, item.date, item.id)}
                   </TableCell>
                 ))}
@@ -222,8 +221,8 @@ export default function Responses(props) {
                 <TableCell>
                   <b>Score</b>
                 </TableCell>
-                {arrData.map((item) => (
-                  <TableCell>
+                {arrData.map((item, index) => (
+                  <TableCell key={`score_cell_${index}`}>
                     {!isNaN(item.score) && (
                       <Score
                         instrumentId={questionnaireId}

--- a/src/components/Responses.js
+++ b/src/components/Responses.js
@@ -64,6 +64,7 @@ export default function Responses(props) {
       field: item.id,
       filterComponent: ({ columnDef, onFilterChanged }) => (
         <Input
+          className="print-hidden"
           arialLabel="Filter"
           placeholder="Filter"
           startAdornment={
@@ -268,6 +269,7 @@ export default function Responses(props) {
               startIcon={<ListAltIcon />}
               {...props}
               ref={ref}
+              className="print-hidden"
             >
               +/- Columns
             </Button>

--- a/src/components/Responses.js
+++ b/src/components/Responses.js
@@ -247,7 +247,13 @@ export default function Responses(props) {
         marginLeft: "auto",
         marginRight: "auto",
         padding: theme.spacing(2),
-        width: "95%",
+        width: "100%",
+        [theme.breakpoints.up("md")]: {
+          width: "95%",
+        },
+        [theme.breakpoints.up("lg")]: {
+          width: "80%",
+        },
         overflowX: "auto",
       }}
     >
@@ -308,6 +314,10 @@ export default function Responses(props) {
       open={open}
       onClose={handleClose}
       TransitionComponent={Transition}
+      transitionDuration={{
+        enter: 500,
+        exit: 500
+      }}
     >
       <AppBar sx={{ position: "relative" }}>
         <Toolbar>

--- a/src/components/Responses.js
+++ b/src/components/Responses.js
@@ -1,156 +1,334 @@
-import { useState } from "react";
+import { forwardRef, useState } from "react";
 import { useTheme } from "@mui/material/styles";
 import { styled } from "@mui/material/styles";
 import PropTypes from "prop-types";
+import MaterialTable from "@material-table/core";
 import Alert from "@mui/material/Alert";
+import AppBar from "@mui/material/AppBar";
 import Box from "@mui/material/Box";
-import Paper from "@mui/material/Paper";
-import Tabs from "@mui/material/Tabs";
-import Tab from "@mui/material/Tab";
+import Button from "@mui/material/Button";
+import Dialog from "@mui/material/Dialog";
+import IconButton from "@mui/material/IconButton";
+import Input from "@mui/material/Input";
+import InputAdornment from "@mui/material/InputAdornment";
+import Slide from "@mui/material/Slide";
+import Stack from "@mui/material/Stack";
 import Table from "@mui/material/Table";
 import TableBody from "@mui/material/TableBody";
 import TableCell from "@mui/material/TableCell";
-import TableContainer from "@mui/material/TableContainer";
 import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
+import Toolbar from "@mui/material/Toolbar";
 import Typography from "@mui/material/Typography";
+import CloseIcon from "@mui/icons-material/Close";
+import Filter from "@mui/icons-material/FilterAlt";
+import OutlinedIcon from "@mui/icons-material/WysiwygOutlined";
+import ListAltIcon from '@mui/icons-material/ListAlt';
 import Score from "./Score";
 
-function TabPanel(props) {
-  const { children, value, index, ...other } = props;
 
-  return (
-    <div
-      role="tabpanel"
-      hidden={value !== index}
-      id={`tabpanel-${index}`}
-      aria-labelledby={`tab-${index}`}
-      {...other}
-    >
-      {value === index && <Box>{children}</Box>}
-    </div>
-  );
-}
-
-TabPanel.propTypes = {
-  children: PropTypes.node,
-  index: PropTypes.number.isRequired,
-  value: PropTypes.number.isRequired,
-};
-
-function a11yProps(index) {
-  return {
-    id: `tab-${index}`,
-    "aria-controls": `tabpanel-${index}`,
-  };
-}
+const Transition = forwardRef(function Transition(props, ref) {
+  return <Slide direction="up" ref={ref} {...props} />;
+});
 
 export default function Responses(props) {
+  const { questionnaireId, questionnaireJson } = props;
+  const [open, setOpen] = useState(false);
   const theme = useTheme();
-  const [tab, setTab] = useState(0);
-  const handleTabChange = (event, newValue) => {
-    setTab(newValue);
-  };
+  const headerBgColor =
+    theme &&
+    theme.palette &&
+    theme.palette.lightest &&
+    theme.palette.lightest.main
+      ? theme.palette.lightest.main
+      : "#FFF";
   const data = props.data || [];
-  const questionnaireId = props.questionnaireId;
+  const dates = data.map((item) => ({ date: item.date, id: item.id }));
+  const columns = [
+    {
+      title: "Questions",
+      field: "question",
+      hiddenByColumnsButton: true,
+      filtering: false,
+      cellStyle: {
+        position: "sticky",
+        left: 0,
+      },
+      render: (rowData) => {
+        if (String(rowData["question"]).toLowerCase() === "score") return <b>{rowData["question"]}</b>
+        else return rowData["question"];
+      },
+    },
+    ...dates.map((item) => ({
+      title: item.date,
+      field: item.id,
+      filterComponent: ({ columnDef, onFilterChanged }) => (
+        <Input
+          arialLabel="Filter"
+          placeholder="Filter"
+          startAdornment={
+            <InputAdornment position="start">
+              <Filter />
+            </InputAdornment>
+          }
+          onChange={(e) => {
+            // Calling the onFilterChanged with the current tableId and the new value
+            onFilterChanged(columnDef.tableData.id, e.target.value);
+          }}
+        />
+      ),
+      render: (rowData) => {
+        if (rowData[item.id].score) {
+          return (
+            <Score
+              instrumentId={questionnaireId}
+              score={rowData[item.id].score}
+            ></Score>
+          );
+        }
+        return rowData[item.id];
+      },
+    })),
+  ];
+
+  const hasData = () => data && data.length > 0 && (data.filter(item => item.responses && item.responses.length).length > 0);
+  const hasScores = () =>
+    data.filter((item) => item.hasOwnProperty("score") && !isNaN(item.score))
+      .length > 0;
+
+  const getData = () => {
+    if (!hasData()) return null;
+    let result = data[0].responses.map((row, index) => {
+      let o = {};
+      o.question = getQuestion(row);
+      dates.forEach((item) => {
+        o[item.id] = getMatchedAnswerByLinkIdDateId(row.id, item.date, item.id);
+      });
+      return o;
+    });
+    if (hasScores()) {
+      let scoringResult = {
+        question: "Score",
+      };
+      data.forEach((item) => (scoringResult[item.id] = { score: item.score }));
+      result.push(scoringResult);
+    }
+    return result;
+  };
+
+  const handleClickOpen = () => {
+    setOpen(true);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+  };
   const getAnswer = (response) => {
     if (!response) return "--";
     return response.value &&
-      (parseInt(response.value.value) === 0 ||
-        response.value.value)
+      (parseInt(response.value.value) === 0 || response.value.value)
       ? response.value.value
-      : (response.answer ? response.answer : "---");
+      : response.answer
+      ? response.answer
+      : "---";
   };
   const getQuestion = (item) => {
     return item.question || item.text || item.id;
   };
-  const hasData = () => data && data.length > 0;
-  const hasResponses = (responses) => responses && Array.isArray(responses) && responses.length > 0;
+
+  const getMatchedAnswerByLinkIdDateId = (
+    question_linkId,
+    responses_date,
+    responses_id
+  ) => {
+    const matchItem = data.filter(
+      (item) => item.id === responses_id && item.date === responses_date
+    );
+    if (!matchItem.length) return "--";
+    const responses = matchItem[0].responses;
+    const answerItem = responses.filter((o) => o.id === question_linkId);
+    if (!answerItem.length) return "--";
+    return getAnswer(answerItem[0]);
+  };
+
+  const getQuestionnaireName = () => {
+    if (!questionnaireJson) return questionnaireId;
+    return questionnaireJson.title
+      ? questionnaireJson.title
+      : questionnaireJson.name;
+  };
 
   const Root = styled("div")(({ theme }) => ({
     width: "100%",
-    [theme.breakpoints.up("lg")]: {
-      width: "50%",
-    },
-    paddingTop: "16px"
+    paddingTop: theme.spacing(1)
   }));
 
   const renderTitle = () => (
-    <Typography
-      variant="subtitle1"
-      gutterBottom
-      component="h2"
-      color="secondary"
-    >
+    <Typography variant="subtitle1" component="h2" color="secondary">
       Questionnaire Responses
     </Typography>
   );
 
-  const renderTabs = () => (
-    <Box>
-      <Tabs
-        value={tab}
-        onChange={handleTabChange}
-        variant="scrollable"
-        scrollButtons="auto"
-        aria-label="responses tabs"
-      >
-        {data.map((item, index) => (
-          <Tab
-            label={item.date}
-            {...a11yProps(index)}
-            key={`tabLabel_${index}`}
-          />
-        ))}
-      </Tabs>
+  const renderPrintOnlyResponseTable = () => {
+    if (!hasData()) return null;
+    const arrDates = dates.filter((item, index) => index < 2);
+    const arrData = data.filter((item, index) => index < 2);
+    // this will render the current and the previous response(s) for print
+    return (
+      <Box className="print-only">
+        <Table
+          aria-label="responses table"
+          size="small"
+          role="table"
+          sx={{ tableLayout: "fixed", width: "100%" }}
+        >
+          <TableHead
+            sx={{
+              backgroundColor:
+                theme && theme.palette.dark ? theme.palette.dark.main : "#444",
+            }}
+          >
+            <TableRow>
+              {["Questions", ...arrDates.map((item) => item.date)].map(
+                (item, index) => (
+                  <TableCell key={`header_${index}`}>{item}</TableCell>
+                )
+              )}
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {data[0].responses.map((row, index) => (
+              <TableRow
+                key={`row_content_${index}`}
+                sx={{
+                  "&:last-child td, &:last-child th": { border: 0 },
+                }}
+              >
+                <TableCell
+                  dangerouslySetInnerHTML={{
+                    __html: getQuestion(row),
+                  }}
+                ></TableCell>
+                {arrDates.map((item, index) => (
+                  <TableCell key={`score_cell_${index}`}>
+                    {getMatchedAnswerByLinkIdDateId(row.id, item.date, item.id)}
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))}
+            {hasScores() && (
+              <TableRow>
+                <TableCell>
+                  <b>Score</b>
+                </TableCell>
+                {arrData.map((item) => (
+                  <TableCell>
+                    {!isNaN(item.score) && (
+                      <Score
+                        instrumentId={questionnaireId}
+                        score={item.score}
+                      ></Score>
+                    )}
+                  </TableCell>
+                ))}
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </Box>
+    );
+  };
+
+  const renderResponseTable = () => (
+    <Box
+      sx={{
+        borderRadius: 0,
+        marginTop: theme.spacing(2),
+        marginLeft: "auto",
+        marginRight: "auto",
+        padding: theme.spacing(2),
+        width: "95%",
+        overflowX: "auto",
+      }}
+    >
+      <MaterialTable
+        columns={columns}
+        data={getData()}
+        icons={{
+          ViewColumn: forwardRef((props, ref) => (
+            <Button
+              variant="outlined"
+              color="secondary"
+              startIcon={<ListAltIcon />}
+              {...props}
+              ref={ref}
+            >
+              +/- Columns
+            </Button>
+          )),
+        }}
+        options={{
+          search: false,
+          showTitle: false,
+          padding: "dense",
+          columnsButton: true,
+          filtering: true,
+          paging: false,
+          thirdSortClick: false,
+          filterCellStyle: {
+            padding: theme.spacing(1),
+            borderRadius: 0,
+          },
+          headerStyle: {
+            backgroundColor: headerBgColor,
+          },
+          rowStyle: (rowData) => ({
+            backgroundColor:
+              rowData.tableData.index % 2 === 0 ? "#f4f4f6" : "#fff",
+          }),
+        }}
+      ></MaterialTable>
     </Box>
   );
 
-  const renderResponseTable = (responses, score) => (
-    <Table aria-label="responses table" size="small" role="table">
-      <TableHead
-        sx={{
-          backgroundColor:
-            theme && theme.palette.dark ? theme.palette.dark.main : "#444",
-        }}
-      >
-        <TableRow>
-          {["Question", "Answer"].map((item, index) => (
-            <TableCell
-              key={`header_${index}`}
-              sx={{ color: "#FFF", width: "50%" }}
-            >
-              {item}
-            </TableCell>
-          ))}
-        </TableRow>
-      </TableHead>
-      <TableBody>
-        {responses.map((row, index) => (
-          <TableRow
-            key={`row_content_${index}`}
-            sx={{
-              "&:last-child td, &:last-child th": { border: 0 },
-            }}
+  const renderOpenIcon = () => (
+    <IconButton
+      color="primary"
+      title="View"
+      size="small"
+      className="print-hidden"
+    >
+      <OutlinedIcon fontSize="medium"></OutlinedIcon>
+    </IconButton>
+  );
+
+  const renderDialog = () => (
+    <Dialog
+      fullScreen
+      open={open}
+      onClose={handleClose}
+      TransitionComponent={Transition}
+    >
+      <AppBar sx={{ position: "relative" }}>
+        <Toolbar>
+          <IconButton
+            edge="start"
+            color="inherit"
+            onClick={handleClose}
+            aria-label="close"
           >
-            <TableCell
-              dangerouslySetInnerHTML={{
-                __html: getQuestion(row),
-              }}
-            ></TableCell>
-            <TableCell>{getAnswer(row)}</TableCell>
-          </TableRow>
-        ))}
-        {!isNaN(score) && (
-          <TableRow>
-            <TableCell><b>Score</b></TableCell>
-            <TableCell>
-              <Score instrumentId={questionnaireId} score={score}></Score>
-            </TableCell>
-          </TableRow>
-        )}
-      </TableBody>
-    </Table>
+            <CloseIcon />
+          </IconButton>
+          <Typography sx={{ ml: 2, flex: 1 }} variant="h6" component="div">
+            Questionnaire Responses for {getQuestionnaireName()}
+          </Typography>
+          <Button autoFocus color="inherit" onClick={handleClose}>
+            Close
+          </Button>
+        </Toolbar>
+      </AppBar>
+      {renderResponseTable()}
+    </Dialog>
   );
 
   return (
@@ -158,21 +336,18 @@ export default function Responses(props) {
       {!hasData() && <Alert severity="warning">No recorded response</Alert>}
       {hasData() && (
         <Root>
-          {renderTitle()}
-          {renderTabs()}
-          {data.map((item, index) => (
-            <TabPanel value={tab} index={index} key={`tabPanel_${index}`}>
-              <TableContainer
-                component={Paper}
-                sx={{ marginTop: theme.spacing(2) }}
-              >
-                {!hasResponses(item.responses) && (
-                  <Alert severity="warning">No responses.</Alert>
-                )}
-                {hasResponses(item.responses) && renderResponseTable(item.responses, item.score)}
-              </TableContainer>
-            </TabPanel>
-          ))}
+          <Stack
+            direction="row"
+            onClick={() => handleClickOpen()}
+            alignItems="center"
+            spacing={1}
+          >
+            {renderTitle()}
+            <div className="print-hidden">( {data.length} )</div>
+            {renderOpenIcon()}
+          </Stack>
+          {renderDialog()}
+          {renderPrintOnlyResponseTable()}
         </Root>
       )}
     </>
@@ -180,6 +355,7 @@ export default function Responses(props) {
 }
 Responses.propTypes = {
   questionnaireId: PropTypes.string,
+  questionnaireJson: PropTypes.object,
   data: PropTypes.arrayOf(
     PropTypes.shape({
       date: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(Date)]),

--- a/src/components/Summaries.js
+++ b/src/components/Summaries.js
@@ -565,7 +565,7 @@ export default function Summaries() {
             className="summaries"
             sx={{
               position: "relative",
-              maxWidth: "1100px",
+              maxWidth: {xs: "100%", sm: "100%", md: "1200px", lg: "1300"},
               margin: "auto",
             }}
           >

--- a/src/components/Summaries.js
+++ b/src/components/Summaries.js
@@ -565,7 +565,7 @@ export default function Summaries() {
             className="summaries"
             sx={{
               position: "relative",
-              maxWidth: {xs: "100%", sm: "100%", md: "1200px", lg: "1300"},
+              maxWidth: "1100px",
               margin: "auto",
             }}
           >

--- a/src/components/Summary.js
+++ b/src/components/Summary.js
@@ -98,8 +98,8 @@ export default function Summary(props) {
   const renderSummary = () =>
     shouldDisplayResponses() && (
       <Stack
-        direction={{ xs: "column", md: "column", lg: "row" }}
-        spacing={{ xs: 2, md: 2, lg: 4 }}
+        direction="column"
+        spacing={{ xs: 2, md: 2, lg: 2 }}
         alignItems="flex-start"
         className="response-summary"
       >
@@ -112,7 +112,6 @@ export default function Summary(props) {
             }}
           ></Chart>
         )}
-
         {!hasResponses() && (
           <Alert severity="warning">No recorded responses</Alert>
         )}
@@ -120,6 +119,7 @@ export default function Summary(props) {
           <Responses
             data={summary.responses}
             questionnaireId={questionnaireId}
+            questionnaireJson={summary.questionnaire}
           ></Responses>
         )}
       </Stack>

--- a/src/components/Summary.js
+++ b/src/components/Summary.js
@@ -99,7 +99,7 @@ export default function Summary(props) {
     shouldDisplayResponses() && (
       <Stack
         direction="column"
-        spacing={{ xs: 2, md: 2, lg: 2 }}
+        spacing={2}
         alignItems="flex-start"
         className="response-summary"
       >

--- a/src/components/graphs/LineCharts.js
+++ b/src/components/graphs/LineCharts.js
@@ -15,7 +15,9 @@ export default function LineCharts(props) {
   const {
     id,
     title,
+    xsChartWidth,
     chartWidth,
+    lgChartWidth,
     chartHeight,
     legendType,
     strokeWidth,
@@ -116,7 +118,7 @@ export default function LineCharts(props) {
       strokeWidth={strokeWidth ? strokeWidth : 2}
     />
   );
-  const MIN_CHART_WIDTH=400;
+  const MIN_CHART_WIDTH = xsChartWidth? xsChartWidth : 400;
   return (
     <>
       {renderTitle()}
@@ -125,6 +127,7 @@ export default function LineCharts(props) {
           width: {
             xs: MIN_CHART_WIDTH,
             sm: chartWidth,
+            lg: lgChartWidth ? lgChartWidth: chartWidth
           },
           height: chartHeight,
         }}

--- a/src/config/chart_config.js
+++ b/src/config/chart_config.js
@@ -20,8 +20,10 @@ const CHART_CONFIG = {
   default: {
     type: "linechart",
     title: "Total Score by Date",
-    chartWidth: 500,
-    chartHeight: 540,
+    xsChartWidth: 400,
+    chartWidth: 520,
+    lgChartWidth: 600,
+    chartHeight: 480,
     xFieldKey: "date",
     xAxisTitle: "Date",
     yAxisTitle: "Score",

--- a/src/cql/ADL-IADL_InterventionLogicLibrary.json
+++ b/src/cql/ADL-IADL_InterventionLogicLibrary.json
@@ -260,6 +260,17 @@
                   "expression" : {
                      "type" : "Tuple",
                      "element" : [ {
+                        "name" : "id",
+                        "value" : {
+                           "path" : "value",
+                           "type" : "Property",
+                           "source" : {
+                              "path" : "id",
+                              "scope" : "I",
+                              "type" : "Property"
+                           }
+                        }
+                     }, {
                         "name" : "date",
                         "value" : {
                            "name" : "DateTimeText",

--- a/src/cql/BEHAV5_InterventionLogicLibrary.json
+++ b/src/cql/BEHAV5_InterventionLogicLibrary.json
@@ -215,6 +215,17 @@
                   "expression" : {
                      "type" : "Tuple",
                      "element" : [ {
+                        "name" : "id",
+                        "value" : {
+                           "path" : "value",
+                           "type" : "Property",
+                           "source" : {
+                              "path" : "id",
+                              "scope" : "I",
+                              "type" : "Property"
+                           }
+                        }
+                     }, {
                         "name" : "date",
                         "value" : {
                            "name" : "DateTimeText",

--- a/src/cql/C-IDAS_InterventionLogicLibrary.json
+++ b/src/cql/C-IDAS_InterventionLogicLibrary.json
@@ -323,6 +323,17 @@
                   "expression" : {
                      "type" : "Tuple",
                      "element" : [ {
+                        "name" : "id",
+                        "value" : {
+                           "path" : "value",
+                           "type" : "Property",
+                           "source" : {
+                              "path" : "id",
+                              "scope" : "I",
+                              "type" : "Property"
+                           }
+                        }
+                     }, {
                         "name" : "date",
                         "value" : {
                            "name" : "DateTimeText",

--- a/src/cql/CP-ECOG_InterventionLogicLibrary.json
+++ b/src/cql/CP-ECOG_InterventionLogicLibrary.json
@@ -269,6 +269,17 @@
                   "expression" : {
                      "type" : "Tuple",
                      "element" : [ {
+                        "name" : "id",
+                        "value" : {
+                           "path" : "value",
+                           "type" : "Property",
+                           "source" : {
+                              "path" : "id",
+                              "scope" : "I",
+                              "type" : "Property"
+                           }
+                        }
+                     }, {
                         "name" : "date",
                         "value" : {
                            "name" : "DateTimeText",

--- a/src/cql/ECOG12_InterventionLogicLibrary.json
+++ b/src/cql/ECOG12_InterventionLogicLibrary.json
@@ -269,6 +269,17 @@
                   "expression" : {
                      "type" : "Tuple",
                      "element" : [ {
+                        "name" : "id",
+                        "value" : {
+                           "path" : "value",
+                           "type" : "Property",
+                           "source" : {
+                              "path" : "id",
+                              "scope" : "I",
+                              "type" : "Property"
+                           }
+                        }
+                     }, {
                         "name" : "date",
                         "value" : {
                            "name" : "DateTimeText",

--- a/src/cql/GAD7_InterventionLogicLibrary.json
+++ b/src/cql/GAD7_InterventionLogicLibrary.json
@@ -224,6 +224,17 @@
                   "expression" : {
                      "type" : "Tuple",
                      "element" : [ {
+                        "name" : "id",
+                        "value" : {
+                           "path" : "value",
+                           "type" : "Property",
+                           "source" : {
+                              "path" : "id",
+                              "scope" : "I",
+                              "type" : "Property"
+                           }
+                        }
+                     }, {
                         "name" : "date",
                         "value" : {
                            "name" : "DateTimeText",

--- a/src/cql/GDS_InterventionLogicLibrary.json
+++ b/src/cql/GDS_InterventionLogicLibrary.json
@@ -612,6 +612,17 @@
                   "expression" : {
                      "type" : "Tuple",
                      "element" : [ {
+                        "name" : "id",
+                        "value" : {
+                           "path" : "value",
+                           "type" : "Property",
+                           "source" : {
+                              "path" : "id",
+                              "scope" : "I",
+                              "type" : "Property"
+                           }
+                        }
+                     }, {
                         "name" : "date",
                         "value" : {
                            "name" : "DateTimeText",

--- a/src/cql/InterventionLogicLibrary.json
+++ b/src/cql/InterventionLogicLibrary.json
@@ -954,6 +954,17 @@
                   "expression" : {
                      "type" : "Tuple",
                      "element" : [ {
+                        "name" : "id",
+                        "value" : {
+                           "path" : "value",
+                           "type" : "Property",
+                           "source" : {
+                              "path" : "id",
+                              "scope" : "I",
+                              "type" : "Property"
+                           }
+                        }
+                     }, {
                         "name" : "date",
                         "value" : {
                            "name" : "DateTimeText",
@@ -1003,7 +1014,7 @@
                "sort" : {
                   "by" : [ {
                      "direction" : "desc",
-                     "path" : "date",
+                     "path" : "authoredDate",
                      "type" : "ByColumn"
                   }, {
                      "direction" : "desc",

--- a/src/cql/MINICOG_InterventionLogicLibrary.json
+++ b/src/cql/MINICOG_InterventionLogicLibrary.json
@@ -297,6 +297,17 @@
                   "expression" : {
                      "type" : "Tuple",
                      "element" : [ {
+                        "name" : "id",
+                        "value" : {
+                           "path" : "value",
+                           "type" : "Property",
+                           "source" : {
+                              "path" : "id",
+                              "scope" : "I",
+                              "type" : "Property"
+                           }
+                        }
+                     }, {
                         "name" : "date",
                         "value" : {
                            "name" : "DateTimeText",

--- a/src/cql/PHQ9_InterventionLogicLibrary.json
+++ b/src/cql/PHQ9_InterventionLogicLibrary.json
@@ -251,6 +251,17 @@
                   "expression" : {
                      "type" : "Tuple",
                      "element" : [ {
+                        "name" : "id",
+                        "value" : {
+                           "path" : "value",
+                           "type" : "Property",
+                           "source" : {
+                              "path" : "id",
+                              "scope" : "I",
+                              "type" : "Property"
+                           }
+                        }
+                     }, {
                         "name" : "date",
                         "value" : {
                            "name" : "DateTimeText",

--- a/src/cql/SLUMS_InterventionLogicLibrary.json
+++ b/src/cql/SLUMS_InterventionLogicLibrary.json
@@ -245,6 +245,17 @@
                   "expression" : {
                      "type" : "Tuple",
                      "element" : [ {
+                        "name" : "id",
+                        "value" : {
+                           "path" : "value",
+                           "type" : "Property",
+                           "source" : {
+                              "path" : "id",
+                              "scope" : "I",
+                              "type" : "Property"
+                           }
+                        }
+                     }, {
                         "name" : "date",
                         "value" : {
                            "name" : "DateTimeText",

--- a/src/cql/source/ADL-IADL_InterventionLogicLibrary.cql
+++ b/src/cql/source/ADL-IADL_InterventionLogicLibrary.cql
@@ -48,6 +48,7 @@ define QuestionnaireResponses:
 define ResponsesSummary:
   (QuestionnaireResponses) I
   return {
+    id: I.id.value,
     date: LogicHelpers.DateTimeText(I.authored),
     responses: LogicHelpers.FormattedResponses(QuestionnaireItems, I.item, ScoringQuestionId),
     score: 

--- a/src/cql/source/BEHAV5_InterventionLogicLibrary.cql
+++ b/src/cql/source/BEHAV5_InterventionLogicLibrary.cql
@@ -43,6 +43,7 @@ define QuestionnaireResponses:
 define ResponsesSummary:
   (QuestionnaireResponses) I
   return {
+    id: I.id.value,
     date: LogicHelpers.DateTimeText(I.authored),
     responses: LogicHelpers.FormattedResponses(QuestionnaireItems, I.item, ScoringQuestionId),
     score: 

--- a/src/cql/source/C-IDAS_InterventionLogicLibrary.cql
+++ b/src/cql/source/C-IDAS_InterventionLogicLibrary.cql
@@ -56,6 +56,7 @@ define QuestionnaireResponses:
 define ResponsesSummary:
   (QuestionnaireResponses) I
   return {
+    id: I.id.value,
     date: LogicHelpers.DateTimeText(I.authored),
     responses: LogicHelpers.FormattedResponses(QuestionnaireItems, I.item, ScoringQuestionId),
     score: 

--- a/src/cql/source/CP-ECOG_InterventionLogicLibrary.cql
+++ b/src/cql/source/CP-ECOG_InterventionLogicLibrary.cql
@@ -49,6 +49,7 @@ define QuestionnaireResponses:
 define ResponsesSummary:
   (QuestionnaireResponses) I
   return {
+    id: I.id.value,
     date: LogicHelpers.DateTimeText(I.authored),
     responses: LogicHelpers.FormattedResponses(QuestionnaireItems, I.item, ScoringQuestionId),
     score: 

--- a/src/cql/source/ECOG12_InterventionLogicLibrary.cql
+++ b/src/cql/source/ECOG12_InterventionLogicLibrary.cql
@@ -49,6 +49,7 @@ define QuestionnaireResponses:
 define ResponsesSummary:
   (QuestionnaireResponses) I
   return {
+    id: I.id.value,
     date: LogicHelpers.DateTimeText(I.authored),
     responses: LogicHelpers.FormattedResponses(QuestionnaireItems, I.item, ScoringQuestionId),
     score: 

--- a/src/cql/source/GAD7_InterventionLogicLibrary.cql
+++ b/src/cql/source/GAD7_InterventionLogicLibrary.cql
@@ -41,6 +41,7 @@ define QuestionnaireResponses:
 define ResponsesSummary:
   (QuestionnaireResponses) I
   return {
+    id: I.id.value,
     date: LogicHelpers.DateTimeText(I.authored),
     responses: LogicHelpers.FormattedResponses(QuestionnaireItems, I.item, ScoringQuestionId),
     currentQ: CurrentQuestionnaire,

--- a/src/cql/source/GDS_InterventionLogicLibrary.cql
+++ b/src/cql/source/GDS_InterventionLogicLibrary.cql
@@ -68,6 +68,7 @@ define ResponsesSummary:
     score14: First(LogicHelpers.getScoringByResponseItem(CurrentQuestionnaire, I.item, question14LinkId)),
     score15: First(LogicHelpers.getScoringByResponseItem(CurrentQuestionnaire, I.item, question15LinkId))
   return {
+    id: I.id.value,
     date: LogicHelpers.DateTimeText(I.authored),
     responses: LogicHelpers.FormattedResponses(QuestionnaireItems, I.item, ScoringQuestionId),
     score: 

--- a/src/cql/source/InterventionLogicLibrary.cql
+++ b/src/cql/source/InterventionLogicLibrary.cql
@@ -96,6 +96,7 @@ define function FormattedResponses(responses List<FHIR.QuestionnaireResponse.Ite
 define ResponsesSummary:
   (QuestionnaireResponses) I
   return {
+    id: I.id.value,
     date: DateTimeText(I.authored),
     responses: FormattedResponses(I.item),
     authoredDate: I.authored,

--- a/src/cql/source/MINICOG_InterventionLogicLibrary.cql
+++ b/src/cql/source/MINICOG_InterventionLogicLibrary.cql
@@ -48,6 +48,7 @@ define ResponsesSummary:
     word_recall_score: Coalesce(First((responses) I where I.id = question1Id return I.value.value), 0),
     clock_draw_score: Coalesce(First((responses) I where I.id = question2Id return I.value.value), 0)
   return {
+    id: I.id.value,
     date: LogicHelpers.DateTimeText(I.authored),
     responses: (responses R where 
     R.id != 'minicog-question1-instruction' and 

--- a/src/cql/source/PHQ9_InterventionLogicLibrary.cql
+++ b/src/cql/source/PHQ9_InterventionLogicLibrary.cql
@@ -48,6 +48,7 @@ define QuestionnaireResponses:
 define ResponsesSummary:
   (QuestionnaireResponses) I
   return {
+    id: I.id.value,
     date: LogicHelpers.DateTimeText(I.authored),
     responses: LogicHelpers.FormattedResponses(QuestionnaireItems, I.item, ScoringQuestionId),
     score: 

--- a/src/cql/source/SLUMS_InterventionLogicLibrary.cql
+++ b/src/cql/source/SLUMS_InterventionLogicLibrary.cql
@@ -38,6 +38,7 @@ define ResponsesSummary:
   let
     responses: LogicHelpers.FormattedResponses(QuestionnaireItems, I.item, ScoringQuestionId)
   return {
+    id: I.id.value,
     date: LogicHelpers.DateTimeText(I.authored),
     responses: responses,
     score: responses[0].value.value,


### PR DESCRIPTION
see https://www.pivotaltracker.com/story/show/184155892
remove tabbed rendering of responses instead of table format rendering

Changes include:
- The responses are hidden on application load.
- User will need to click on the show icon to see the responses (please screenshot).
![Screen Shot 2023-01-06 at 9 58 26 AM](https://user-images.githubusercontent.com/12942714/211076166-d35a8804-46d9-4403-a3f9-6326b42ffc0f.png)
- On clicking on the icon, a full screen dialog will popup that contains the responses (see screenshot).
![Screen Shot 2023-01-06 at 9 58 11 AM](https://user-images.githubusercontent.com/12942714/211076058-61f76b1e-04ed-4598-abb0-bfad59e22455.png)
