### PR TITLE
remove _count from default query parameter for FHIR query

### DIFF
--- a/src/util/fhirUtil.js
+++ b/src/util/fhirUtil.js
@@ -65,8 +65,7 @@ export function getFHIRResourceTypesToLoad() {
 export function getFHIRResourceQueryParams(resourceType, options) {
   if (!resourceType) return null;
   let paramsObj = {
-    _sort: "-_lastUpdated",
-    _count: 100,
+    _sort: "-_lastUpdated"
   };
   const queryOptions = options ? options : {};
   const envCategory = getEnv("REACT_APP_FHIR_CAREPLAN_CATEGORY");


### PR DESCRIPTION
per #24 remove default `_count` query parameter from code when executing FHIR query.