### PR TITLE
update response displays per feedback

### DIFF
--- a/src/components/ResponsesTable.jsx
+++ b/src/components/ResponsesTable.jsx
@@ -148,9 +148,9 @@ export default function ResponsesTable({
                     }}
                   >
                     {/* Column titles are developer-supplied, rendered as plain text */}
-                    {col.title}
+                    <Box>{col.title}</Box>
                     {col.source && (
-                      <span className="source-container">{col.source}</span>
+                      <Box className="source-container">{col.source}</Box>
                     )}
                   </TableCell>
                 );

--- a/src/components/sections/PROReport.jsx
+++ b/src/components/sections/PROReport.jsx
@@ -53,7 +53,7 @@ const TwoColumns = React.memo(function TwoColumns({ table }) {
   );
 });
 TwoColumns.propTypes = {
-  table: React.object,
+  table: PropTypes.object,
 };
 
 // --- TableItem component ---

--- a/src/config/questionnaire_configs/CIRG_CNICS_FINANCIAL.js
+++ b/src/config/questionnaire_configs/CIRG_CNICS_FINANCIAL.js
@@ -15,5 +15,5 @@ export default {
   },
   alertQuestionId: "FINANCIAL-critical-flag",
   meaningQuestionId: "FINANCIAL-score-label",
-  skipResponses: true,
+  skipMeaningScoreRow: true,
 };

--- a/src/config/questionnaire_configs/CIRG_CNICS_FOOD.js
+++ b/src/config/questionnaire_configs/CIRG_CNICS_FOOD.js
@@ -18,4 +18,5 @@ export default {
       meaningResponse?.answer != null && meaningResponse.answer !== undefined ? meaningResponse.answer : null;
     return meaningAnswer ? capitalizeFirstLetterSafe(String(meaningAnswer)) : "";
   },
+  meaningRowLabel: "Summary",
 };

--- a/src/config/questionnaire_configs/CIRG_CNICS_SEXUAL_RISK.js
+++ b/src/config/questionnaire_configs/CIRG_CNICS_SEXUAL_RISK.js
@@ -52,7 +52,7 @@ export const CIRG_SEXUAL_PARTNER_CONTEXT = {
   instrumentName: "Sexual Partner Context",
   title: "Sexual Partner Context",
   subtitle: "Past 3 months",
-  skipResponses: true,
+  skipMeaningScoreRow: true,
   deriveFrom: {
     hostIds: ["CIRG-CNICS-SEXUAL-RISK"],
     linkIds: [

--- a/src/consts/index.js
+++ b/src/consts/index.js
@@ -157,7 +157,6 @@ export const IS_QUESTION_COLUMN_KEYWORDS = [
   "meaning",
   "summary",
   "visual analog scale",
-  "status",
 ];
 
 export const EMPTY_CELL_STRING = "-";

--- a/src/models/resultBuilders/QuestionnaireScoringBuilder.js
+++ b/src/models/resultBuilders/QuestionnaireScoringBuilder.js
@@ -597,10 +597,12 @@ export default class QuestionnaireScoringBuilder extends FhirResultBuilder {
       // Prefer human display for codings
       const coding = this.answerCoding(item);
       if (coding) {
+        const normalizedCode = coding.code != null ? String(coding.code).toLowerCase() : null;
+        const displayValue = coding.display ?? (normalizedCode ? fallbackScoreMap[normalizedCode] : null);
+        if (isNonEmptyString(displayValue)) return displayValue;
         const fromExt = this.readOrdinalExt(coding);
         if (fromExt != null && isNumber(fromExt)) return fromExt;
-        const normalizedCode = coding.code != null ? String(coding.code).toLowerCase() : null;
-        return coding.display ?? (normalizedCode ? fallbackScoreMap[normalizedCode] : null) ?? null;
+        return null;
       }
 
       // Then any primitive value[x]
@@ -1069,13 +1071,12 @@ export default class QuestionnaireScoringBuilder extends FhirResultBuilder {
             question = this._getQuestion(questionnaireItem, resolvedConfig);
           }
           row.question = question ? question : `Question ${questionId}`;
-
           row.source = sample?.source;
           row.readOnly = sample?.readOnly || false;
           row.isValueExpression = sample?.isValueExpression || false;
           row.isHelp = sample?.isHelp || false;
           row.config = resolvedConfig;
-
+      
           // answer retrieval
           for (const dataItem of formattedData) {
             let matchedResponse = null;
@@ -1097,7 +1098,7 @@ export default class QuestionnaireScoringBuilder extends FhirResultBuilder {
 
             const rowAnswer = matchedResponse ? this._getAnswer(matchedResponse, resolvedConfig) : null;
             row[dataItem.id] = rowAnswer;
-            row[`${dataItem.id}_data`] = getScoreParamsFromResponses([dataItem], resolvedConfig);
+            row[`${dataItem.id}_scoreParams`] = getScoreParamsFromResponses([dataItem], resolvedConfig);
           }
 
           return row;

--- a/src/models/resultBuilders/helpers.jsx
+++ b/src/models/resultBuilders/helpers.jsx
@@ -756,7 +756,7 @@ export function getScoreParamsFromResponses(responses, config = {}) {
   const current = getMostRecentResponseRow(responses);
   const prev = getPreviousResponseRowWithScore(responses);
 
-  const curScore = current.score != null ? current.score : null;
+  const curScore = current?.score != null ? current.score : null;
   const prevScore = prev?.score != null ? prev.score : null;
   const minScore = isNumber(config?.minimumScore) ? config?.minimumScore : 0;
   const maxScore = isNumber(config?.maximumScore) ? config?.maximumScore : null;

--- a/src/style/App.scss
+++ b/src/style/App.scss
@@ -200,6 +200,12 @@ p {
 }
 .responses-container,
 .scoring-summary-table {
+  td.alert-cell {
+    background-color: $danger-background-color;
+  }
+  td.warning-cell {
+    background-color: $warning-background-color;
+  }
   td:has(.text-warning) {
     background-color: $warning-background-color;
   }
@@ -253,7 +259,6 @@ p {
   }
   tr:has(.question-row) {
     td {
-      background-color: #fff !important;
       line-height: 1.5;
       padding: 4px 8px !important;
     }


### PR DESCRIPTION
Feedback from Lydia, see [Slack convo](https://cirg.slack.com/archives/C012XAUQULB/p1772127330473759)

Changes include:
Fix questionnaire configs for:
- Financial Situation: show responses
- AUDIT & AUDIT-C, MINI show text responses instead of numeric responses
- Sexual Partner Context: show responses for each, gender of partner, HIV & PrEP status of partner,etc.
Other changes:
- minor cell style fixes
- fix propType error