### PR TITLE
Feature/hiv stigma display mapping

### DIFF
--- a/src/config/questionnaire_configs/CIRG_CNICS_HIV_STIGMA.js
+++ b/src/config/questionnaire_configs/CIRG_CNICS_HIV_STIGMA.js
@@ -9,27 +9,15 @@ export default {
   scoringQuestionId: "HIV-STIGMA-SCORE",
   showNumAnsweredWithScore: true,
   totalAnsweredQuestionId: "HIV-STIGMA-SCORE-NUM-ANSWERED",
-  fallbackScoreMap: {
-    "HIV-STIGMA-0-0": "Strongly disagree",
-    "HIV-STIGMA-0-1": "Disagree",
-    "HIV-STIGMA-0-2": "Neither disagree nor agree",
-    "HIV-STIGMA-0-3": "Agree",
-    "HIV-STIGMA-0-4": "Strongly agree",
-    "HIV-STIGMA-1-0": "Strongly disagree",
-    "HIV-STIGMA-1-1": "Disagree",
-    "HIV-STIGMA-1-2": "Neither disagree nor agree",
-    "HIV-STIGMA-1-3": "Agree",
-    "HIV-STIGMA-1-4": "Strongly agree",
-    "HIV-STIGMA-2-0": "Strongly disagree",
-    "HIV-STIGMA-2-1": "Disagree",
-    "HIV-STIGMA-2-2": "Neither disagree nor agree",
-    "HIV-STIGMA-2-3": "Agree",
-    "HIV-STIGMA-2-4": "Strongly agree",
-    "HIV-STIGMA-3-0": "Strongly disagree",
-    "HIV-STIGMA-3-1": "Disagree",
-    "HIV-STIGMA-3-2": "Neither disagree nor agree",
-    "HIV-STIGMA-3-3": "Agree",
-    "HIV-STIGMA-3-4": "Strongly agree", 
+  valueFormatter: (val) => {
+    const mappings = {
+      1: "Strongly disagree",
+      2: "Disagree",
+      3: "Neither disagree nor agree",
+      4: "Agree",
+      5: "Strongly agree"
+    };
+    return mappings[val] || val;
   },
   noteFunction: (questionnaire) => {
     if (!questionnaire) return "";

--- a/src/config/questionnaire_configs/CIRG_CNICS_HIV_STIGMA.js
+++ b/src/config/questionnaire_configs/CIRG_CNICS_HIV_STIGMA.js
@@ -9,6 +9,28 @@ export default {
   scoringQuestionId: "HIV-STIGMA-SCORE",
   showNumAnsweredWithScore: true,
   totalAnsweredQuestionId: "HIV-STIGMA-SCORE-NUM-ANSWERED",
+  fallbackScoreMap: {
+    "HIV-STIGMA-0-0": "Strongly disagree",
+    "HIV-STIGMA-0-1": "Disagree",
+    "HIV-STIGMA-0-2": "Neither disagree nor agree",
+    "HIV-STIGMA-0-3": "Agree",
+    "HIV-STIGMA-0-4": "Strongly agree",
+    "HIV-STIGMA-1-0": "Strongly disagree",
+    "HIV-STIGMA-1-1": "Disagree",
+    "HIV-STIGMA-1-2": "Neither disagree nor agree",
+    "HIV-STIGMA-1-3": "Agree",
+    "HIV-STIGMA-1-4": "Strongly agree",
+    "HIV-STIGMA-2-0": "Strongly disagree",
+    "HIV-STIGMA-2-1": "Disagree",
+    "HIV-STIGMA-2-2": "Neither disagree nor agree",
+    "HIV-STIGMA-2-3": "Agree",
+    "HIV-STIGMA-2-4": "Strongly agree",
+    "HIV-STIGMA-3-0": "Strongly disagree",
+    "HIV-STIGMA-3-1": "Disagree",
+    "HIV-STIGMA-3-2": "Neither disagree nor agree",
+    "HIV-STIGMA-3-3": "Agree",
+    "HIV-STIGMA-3-4": "Strongly agree", 
+  },
   noteFunction: (questionnaire) => {
     if (!questionnaire) return "";
     const matchedItem = questionnaire.item.find((o) => o.linkId === "HIV-STIGMA-SCORE");

--- a/src/models/resultBuilders/QuestionnaireScoringBuilder.js
+++ b/src/models/resultBuilders/QuestionnaireScoringBuilder.js
@@ -599,8 +599,9 @@ export default class QuestionnaireScoringBuilder extends FhirResultBuilder {
       const coding = this.answerCoding(item);
       if (coding) {
         const normalizedCode = coding.code != null ? String(coding.code).toLowerCase() : null;
+        const normalizedFallbackValue = normalizedCode ? fallbackScoreMap[normalizedCode] : null;
         const codeDisplay = NOT_TO_SHOW_CODE_DISPLAY_VALUES.includes(coding.display) ? null : coding.display;
-        const displayValue = codeDisplay ?? (normalizedCode ? fallbackScoreMap[normalizedCode] : null);
+        const displayValue = normalizedFallbackValue ?? codeDisplay;
         if (isNonEmptyString(displayValue)) return displayValue;
         const fromExt = this.readOrdinalExt(coding);
         if (fromExt != null && isNumber(fromExt)) return fromExt;


### PR DESCRIPTION
Display text equivalent of numeric answer for HIV STIGMA.
There is no text equivalent in the questionnaireResponse currently:

```
{
            "linkId": "HIV-STIGMA-1",
            "text": "Having HIV is disgusting to me",
            "answer": [
              {
                "valueCoding": {
                  "extension": [
                    {
                      "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
                      "valueDecimal": 4
                    }
                  ],
                  "system": "https://cnics-pro.cirg.washington.edu/",
                  "code": "HIV-STIGMA-1-3",
                  "display": "%(WIDGET)"
                }
              }
            ]
          },
          {
            "linkId": "HIV-STIGMA-2",
            "text": "I feel ashamed of having HIV",
            "answer": [
              {
                "valueCoding": {
                  "extension": [
                    {
                      "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
                      "valueDecimal": 4
                    }
                  ],
                  "system": "https://cnics-pro.cirg.washington.edu/",
                  "code": "HIV-STIGMA-2-3",
                  "display": "%(WIDGET)"
                }
              }
            ]
          }
```

Fix is to provide fallback text for the numeric value.

Before:
<img width="831" height="66" alt="Screenshot 2026-02-27 at 10 57 33 AM" src="https://github.com/user-attachments/assets/7a43d2b8-5c8c-4530-ae71-fa3467dcb060" />

After
<img width="837" height="60" alt="Screenshot 2026-02-27 at 10 57 53 AM" src="https://github.com/user-attachments/assets/a457afca-90dc-4399-bba1-f9375378dc4f" />


