### PR TITLE
hid shortness of breath row

### DIFF
--- a/src/config/report_config.jsx
+++ b/src/config/report_config.jsx
@@ -21,7 +21,7 @@ export const report_config = {
             "CIRG-CNICS-FINANCIAL",
             "CIRG-CNICS-HOUSING",
             "CIRG-CNICS-FROP-Com",
-            "CIRG-Shortness-of-Breath",
+          //  "CIRG-Shortness-of-Breath",
           ],
           hiddenColumns: ["numAnswered"],
         },


### PR DESCRIPTION
- hide the row for shortness of breath (see screenshot) since we don't have data to display for. It seems pointless to show if there is nothing there yet.

<img width="595" height="84" alt="Screenshot 2026-02-27 at 1 39 14 PM" src="https://github.com/user-attachments/assets/cd0c6512-d344-4a19-b41a-ca3928c9c9c6" />
