### PR TITLE
Feature/save snapshot

### DIFF
--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -1,10 +1,10 @@
-import React, { useCallback, useMemo } from "react";
+import React, { useCallback, useContext, useEffect, useRef, useMemo } from "react";
 import PropTypes from "prop-types";
 import Alert from "@mui/material/Alert";
 import Box from "@mui/material/Box";
 import Stack from "@mui/material/Stack";
 import ErrorIcon from "@mui/icons-material/ErrorOutlined";
-import { getAppHeight, getSectionsToShow, isEmptyArray } from "@util";
+import { getAppHeight, getSectionsToShow, isEmptyArray, saveHTMLToFHIR } from "@util";
 import ErrorComponent from "./ErrorComponent";
 import Loader from "./Loader";
 import ProgressIndicator from "./ProgressIndicator";
@@ -12,6 +12,7 @@ import Section from "./Section";
 import Version from "./Version";
 import FloatingNavButton from "./FloatingNavButton";
 import useFetchResources from "@/hooks/useFetchResources";
+import { FhirClientContext } from "@/context/FhirClientContext";
 
 const MemoizedSection = React.memo(function MemoizedSection({ section, data }) {
   return <Section section={section} data={data}></Section>;
@@ -33,11 +34,16 @@ const ERROR_SECTION_BASE = {
   icon: () => <ErrorIcon />,
 };
 
+let debounceTimer = null;
+
 export default function Dashboard() {
   const { hasError, errorMessages, errorSeverity, fatalError, isReady, toBeLoadedResources, ...otherResults } =
     useFetchResources();
   const data = useMemo(() => ({ ...otherResults }), [otherResults]);
   const sectionsToShow = getSectionsToShow();
+  const { client, patient } = useContext(FhirClientContext);
+  const hasSavedSnapshot = useRef(false);
+  const sectionsRef = useRef(null);
 
   const renderSections = useCallback(() => {
     if (isEmptyArray(sectionsToShow)) return <Alert severity="warning">No section to show.</Alert>;
@@ -72,6 +78,31 @@ export default function Dashboard() {
     margin: "auto",
   };
 
+  useEffect(() => {
+    if (!isReady || hasSavedSnapshot.current || !sectionsRef.current) return;
+
+    // MutationObserver watches for actual DOM changes in the sections container,
+    // so we only snapshot after child content (charts, tables) is truly in the DOM
+    const observer = new MutationObserver(() => {
+      clearTimeout(debounceTimer);
+      debounceTimer = setTimeout(() => {
+        requestAnimationFrame(() => {
+          if (hasSavedSnapshot.current) return;
+          hasSavedSnapshot.current = true;
+          observer.disconnect();
+          saveHTMLToFHIR(client, patient?.id).catch(console.error);
+        });
+      }, 500); // wait 500ms of DOM quiet before snapshotting
+    });
+
+    observer.observe(sectionsRef.current, {
+      childList: true, // watches for sections being added
+      subtree: true, // watches all descendants (charts, table rows, etc.)
+      attributes: false,
+    });
+
+    return () => observer.disconnect();
+  }, [isReady, client, patient]);
   return (
     <Box className="app">
       {!isReady && (
@@ -87,7 +118,7 @@ export default function Dashboard() {
         <>
           <FloatingNavButton></FloatingNavButton>
           <Stack className="summaries" sx={mainStackStyleProps}>
-            <section style={{ minHeight: getAppHeight() }}>
+            <section ref={sectionsRef} style={{ minHeight: getAppHeight() }}>
               {hasError && renderError()}
               {!fatalError && renderSections()}
             </section>

--- a/src/components/sections/PROReport.jsx
+++ b/src/components/sections/PROReport.jsx
@@ -106,7 +106,7 @@ TableItem.propTypes = {
 // --- PrintChunks component ---
 const PrintChunks = React.memo(function PrintChunks({ section }) {
   return (
-    <Box className="print-only">
+    <Box className="print-only print-table-chunk">
       {section.tables.flatMap((table) =>
         (table.rows ?? []).flatMap((row) =>
           (row.printColumnChunks ?? []).map((chunk, i) => (
@@ -151,7 +151,7 @@ export default function PROReport() {
   return (
     <>
       {sections}
-      <Box className="print-only history-block">{printTables}</Box>
+      <Box className="print-only history-block print-chunks-history">{printTables}</Box>
     </>
   );
 }

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -1,16 +1,11 @@
 import dayjs from "dayjs";
 import ChartConfig from "@config/chart_config";
 import defaultSections, { sections } from "@config/sections_config";
-<<<<<<< Updated upstream
-import { DEFAULT_TOOLBAR_HEIGHT, QUESTIONNAIRE_ANCHOR_ID_PREFIX, queryNeedPatientBanner } from "@/consts";
-=======
 import {
   DEFAULT_TOOLBAR_HEIGHT,
-  HELP_HTML_TEXT,
   QUESTIONNAIRE_ANCHOR_ID_PREFIX,
   queryNeedPatientBanner,
 } from "@/consts";
->>>>>>> Stashed changes
 
 export const shortDateRE = /^\d{4}-\d{2}-\d{2}$/; // matches '2012-04-05'
 export const dateREZ =

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -1,7 +1,16 @@
 import dayjs from "dayjs";
 import ChartConfig from "@config/chart_config";
 import defaultSections, { sections } from "@config/sections_config";
+<<<<<<< Updated upstream
 import { DEFAULT_TOOLBAR_HEIGHT, QUESTIONNAIRE_ANCHOR_ID_PREFIX, queryNeedPatientBanner } from "@/consts";
+=======
+import {
+  DEFAULT_TOOLBAR_HEIGHT,
+  HELP_HTML_TEXT,
+  QUESTIONNAIRE_ANCHOR_ID_PREFIX,
+  queryNeedPatientBanner,
+} from "@/consts";
+>>>>>>> Stashed changes
 
 export const shortDateRE = /^\d{4}-\d{2}-\d{2}$/; // matches '2012-04-05'
 export const dateREZ =
@@ -452,11 +461,11 @@ export function generateUUID() {
     var r = Math.random() * 16; //random number between 0 and 16
     if (d > 0) {
       //Use timestamp until depleted
-      r = (d + r) % 16 | 0;
+      r = ((d + r) % 16) | 0;
       d = Math.floor(d / 16);
     } else {
       //Use microseconds since page-load if supported
-      r = (d2 + r) % 16 | 0;
+      r = ((d2 + r) % 16) | 0;
       d2 = Math.floor(d2 / 16);
     }
     return (c === "x" ? r : (r & 0x3) | 0x8).toString(16);
@@ -528,4 +537,94 @@ export function capitalizeFirstLetterSafe(text) {
   if (typeof text !== "string" || text.length === 0) return text;
   const textStr = String(text).replace(/"/g, "").trim();
   return textStr.charAt(0).toUpperCase() + textStr.slice(1).toLowerCase();
+}
+
+export function captureFullHTML() {
+  // 1. Force-expand all collapsed MUI accordions
+  const collapseEls = document.querySelectorAll(".MuiCollapse-root");
+  const originalStyles = Array.from(collapseEls).map((el) => ({
+    el,
+    height: el.style.height,
+    overflow: el.style.overflow,
+    visibility: el.style.visibility,
+  }));
+
+  collapseEls.forEach((el) => {
+    el.style.height = "auto";
+    el.style.overflow = "visible";
+    el.style.visibility = "visible";
+  });
+
+  // 2. Capture the HTML
+  const rootEl = document.getElementById("root");
+  const styles = Array.from(document.styleSheets)
+    .flatMap((sheet) => {
+      try {
+        return Array.from(sheet.cssRules).map((r) => r.cssText);
+      } catch {
+        return [];
+      }
+    })
+    .join("\n");
+
+  const html = `<!DOCTYPE html>
+<html>
+  <head>
+    <style>
+      ${styles}
+      * { -webkit-print-color-adjust: exact !important; print-color-adjust: exact !important; }
+      .MuiCollapse-root { height: auto !important; overflow: visible !important; visibility: visible !important; }
+      .MuiCollapse-hidden { height: auto !important; visibility: visible !important; }
+      .MuiAccordionDetails-root { display: block !important; }
+      button, .floating-nav-button { display: none !important; }
+      body { background: white !important; padding: 16px; }
+      svg, canvas { max-width: 100% !important; overflow: visible !important; }
+      section, .MuiAccordion-root, table { break-inside: avoid; page-break-inside: avoid; }
+      .print-chunks-history { display: block !important;}
+      .print-table-chunk {display: block !important;}
+    </style>
+  </head>
+  <body>${rootEl?.innerHTML ?? ""}</body>
+</html>`;
+
+  // 3. Restore accordion states so user's UI is unaffected
+  originalStyles.forEach(({ el, height, overflow, visibility }) => {
+    el.style.height = height;
+    el.style.overflow = overflow;
+    el.style.visibility = visibility;
+  });
+
+  return html;
+}
+
+export function getSnapshotDocRefId(patientId) {
+  return `proreport-snapshot-${patientId}`;
+}
+
+export async function saveHTMLToFHIR(client, patientId) {
+  if (!client || !patientId) return null;
+  const html = captureFullHTML();
+  const encoded = btoa(unescape(encodeURIComponent(html)));
+  const resourceId = getSnapshotDocRefId(patientId);
+
+  const docRef = {
+    resourceType: "DocumentReference",
+    id: resourceId, // required for PUT
+    status: "current",
+    subject: { reference: `Patient/${patientId}` },
+    date: new Date().toISOString(),
+    description: "PRO report UI snapshot",
+    content: [
+      {
+        attachment: {
+          contentType: "text/html",
+          data: encoded,
+          title: "Report HTML Snapshot",
+          creation: new Date().toISOString(),
+        },
+      },
+    ],
+  };
+  // PUT will create-or-update in place — no duplicate resources
+  return await client.update(docRef);
 }

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -535,22 +535,7 @@ export function capitalizeFirstLetterSafe(text) {
 }
 
 export function captureFullHTML() {
-  // 1. Force-expand all collapsed MUI accordions
-  const collapseEls = document.querySelectorAll(".MuiCollapse-root");
-  const originalStyles = Array.from(collapseEls).map((el) => ({
-    el,
-    height: el.style.height,
-    overflow: el.style.overflow,
-    visibility: el.style.visibility,
-  }));
-
-  collapseEls.forEach((el) => {
-    el.style.height = "auto";
-    el.style.overflow = "visible";
-    el.style.visibility = "visible";
-  });
-
-  // 2. Capture the HTML
+  // Capture the HTML
   const rootEl = document.getElementById("root");
   const styles = Array.from(document.styleSheets)
     .flatMap((sheet) => {
@@ -562,32 +547,18 @@ export function captureFullHTML() {
     })
     .join("\n");
 
+  // this allows tables in detail modal to be captured as separate tables
   const html = `<!DOCTYPE html>
 <html>
   <head>
     <style>
       ${styles}
-      * { -webkit-print-color-adjust: exact !important; print-color-adjust: exact !important; }
-      .MuiCollapse-root { height: auto !important; overflow: visible !important; visibility: visible !important; }
-      .MuiCollapse-hidden { height: auto !important; visibility: visible !important; }
-      .MuiAccordionDetails-root { display: block !important; }
-      button, .floating-nav-button { display: none !important; }
-      body { background: white !important; padding: 16px; }
-      svg, canvas { max-width: 100% !important; overflow: visible !important; }
-      section, .MuiAccordion-root, table { break-inside: avoid; page-break-inside: avoid; }
       .print-chunks-history { display: block !important;}
       .print-table-chunk {display: block !important;}
     </style>
   </head>
   <body>${rootEl?.innerHTML ?? ""}</body>
 </html>`;
-
-  // 3. Restore accordion states so user's UI is unaffected
-  originalStyles.forEach(({ el, height, overflow, visibility }) => {
-    el.style.height = height;
-    el.style.overflow = overflow;
-    el.style.visibility = visibility;
-  });
 
   return html;
 }


### PR DESCRIPTION
As per meeting.

Save a snapshot of the report HTML as DocumentReference resource on page load.

Example resource saved:
```
{
  "resourceType": "DocumentReference",
  "id": "proreport-snapshot-5ee05359-57bf-4cee-8e89-91382c07e162",
  "body": {
    "resourceType": "DocumentReference",
    "id": "proreport-snapshot-5ee05359-57bf-4cee-8e89-91382c07e162",
    "status": "current",
    "subject": { "reference": "Patient/5ee05359-57bf-4cee-8e89-91382c07e162" },
    "date": "2026-03-04T20:23:55.210Z",
    "description": "PRO report UI snapshot",
    "content": [
      {
        "attachment": {
          "contentType": "text/html",
          "data": [HTML in base64],
          "title": "Report HTML Snapshot",
          "creation": "2026-03-04T20:23:55.210Z"
        }
      }
    ]
  }
}


```