### PR TITLE
add flag symbol for alert meaning, fix audit colors

### DIFF
--- a/src/config/questionnaire_configs/CIRG_CNICS_AUDIT.js
+++ b/src/config/questionnaire_configs/CIRG_CNICS_AUDIT.js
@@ -53,8 +53,8 @@ export default {
     xLabel: "",
     scoringQuestionId: "AUDIT-score",
     yLineFields: [
-      { key: "AUDIT-C-score", color: "#498C8A", strokeWidth: 1, legendType: "line", strokeOpacity: 0.6 },
-      { key: "AUDIT-score", color: "#600876", strokeWidth: 1, strokeOpacity: 0.6, legendType: "line" },
+      { key: "AUDIT-C-score", color: "#FF8C00", strokeWidth: 1, legendType: "line", strokeOpacity: 0.6 },
+      { key: "AUDIT-score", color: "#0000FF", strokeWidth: 1, strokeOpacity: 0.6, legendType: "line" },
     ],
     showTooltipMeaning: false,
   },

--- a/src/config/report_config.jsx
+++ b/src/config/report_config.jsx
@@ -2,6 +2,7 @@ import { Box, Stack } from "@mui/material";
 import { getNoDataDisplay } from "@models/resultBuilders/helpers";
 import { getLocaleDateStringFromDate, isEmptyArray } from "@util";
 import ResponsesViewer from "@components/ResponsesViewer";
+import Meaning from "@components/Meaning";
 
 export const report_config = {
   sections: [
@@ -90,7 +91,7 @@ export const report_config = {
           id: "table_art_adherence",
           layout: "two-columns",
           dataKeysToMatch: ["CIRG-SRS", "CIRG-Last-Missed-Dose", "CIRG-VAS"],
-          title: "Antiretroviral (ART) Adherence",
+          title: "Adherence to Antiretroviral Therapy (ART)",
           hiddenColumns: ["id", "source", "numAnswered", "scoreMeaning", "comparison"],
           columns: [
             {
@@ -215,16 +216,15 @@ export const report_config = {
                 if (!isEmptyArray(values)) {
                   return (
                     <Stack direction={"column"} gap={0.5}>
-                      {values.map((value, index) => (
-                        <span className={`${row?.alert ? "text-danger" : ""}`} key={`${row.key}_value_${index}`}>
-                          {value}
-                        </span>
-                      ))}
+                      {values.map((value, index) => {
+                        const {key, ...rest} = row;
+                        return <Meaning key={`${key}_value_${index}`} {...rest} meaning={value}/>
+                      })}
                     </Stack>
                   );
                 }
                 if (row?.meaning) {
-                  return <span className={`${row?.alert ? "text-danger" : ""}`}>{row.meaning}</span>;
+                  return <Meaning {...row}/>
                 }
                 return getNoDataDisplay();
               },


### PR DESCRIPTION
Per feedback in [Slack](https://cirg.slack.com/archives/C012XAUQULB/p1773448390073079)
- Add flag symbol for red text
- fix colors for audit graph, tested using [Coblis tool for color blindness](https://www.color-blindness.com/coblis-color-blindness-simulator)
- fix ARV adherence title