### PR TITLE
ARV display fixes

### DIFF
--- a/src/config/questionnaire_configs/CIRG_CNICS_ARV.js
+++ b/src/config/questionnaire_configs/CIRG_CNICS_ARV.js
@@ -11,9 +11,6 @@ export const CIRG_CNICS_ARV_MISSED_DOSE = makeArvDerivedConfig(
   "ARV-last-missed",
   "Last Missed Dose",
   "Last Missed Dose",
-  {
-    subtitle: "Past 4 weeks",
-  },
 );
 
 export const CIRG_CNICS_ARV_SRS = makeArvDerivedConfig(
@@ -30,7 +27,7 @@ export const CIRG_CNICS_ARV_SRS = makeArvDerivedConfig(
 export const CIRG_CNICS_ARV_VAS = {
   ...BASE_CONFIG,
   title: "Percent ART taken",
-  subtitle: "Past 4 weeks",
+  subtitle: "Past 30 days",
   instrumentName: "VAS",
   scoringQuestionId: "ARV-VAS",
   deriveFrom: {


### PR DESCRIPTION
[Per Slack feedback](https://cirg.slack.com/archives/C012XAUQULB/p1773870128236309) 
- Remove Past 4 week subtitle from Last Missed Dose row
- Update subtitle for Percept ART Taken from Past 4 Weeks to Past 30 Days