### PR TITLE
Feature/header return url

### DIFF
--- a/src/layout/Header.jsx
+++ b/src/layout/Header.jsx
@@ -46,7 +46,9 @@ export default function Header(props) {
   const sections = getSectionsToShow();
   const shouldShowSections = sections && sections.length > 1;
   const { returnURL, inEHR } = props;
-  const locationEvent = () => window.location.href = returnURL ?? "/";
+  // return URL is provided when launching the app via FEMR, e.g. dashboard URL
+  const LOCATION_URL = returnURL ? returnURL + "/clear_session" : null;
+  const locationEvent = () => window.location.href = LOCATION_URL?? "/";
   const getDesktopImgSrc = async () => {
     const projectUrl = toAbsoluteUrl(`/assets/${getEnvProjectId()}/img/logo.png`);
     const ok = await isImagefileExist(projectUrl).catch(() => false);
@@ -200,7 +202,7 @@ export default function Header(props) {
       <Box className="print-hidden">
         <Button
           color="primary"
-          href={returnURL}
+          href={LOCATION_URL}
           className="btn-return-url"
           startIcon={<ArrowBackIcon></ArrowBackIcon>}
           size="medium"

--- a/src/layout/Header.jsx
+++ b/src/layout/Header.jsx
@@ -47,7 +47,7 @@ export default function Header(props) {
   const shouldShowSections = sections && sections.length > 1;
   const { returnURL, inEHR } = props;
   // return URL is provided when launching the app via FEMR, e.g. dashboard URL
-  const LOCATION_URL = returnURL ? returnURL + "/clear_session" : null;
+  const LOCATION_URL = returnURL ? returnURL : null;
   const locationEvent = () => window.location.href = LOCATION_URL?? "/";
   const getDesktopImgSrc = async () => {
     const projectUrl = toAbsoluteUrl(`/assets/${getEnvProjectId()}/img/logo.png`);

--- a/src/layout/Header.jsx
+++ b/src/layout/Header.jsx
@@ -45,8 +45,8 @@ export default function Header(props) {
   const mobileImgRef = useRef(null);
   const sections = getSectionsToShow();
   const shouldShowSections = sections && sections.length > 1;
-
   const { returnURL, inEHR } = props;
+  const locationEvent = () => window.location.href = returnURL ?? "/";
   const getDesktopImgSrc = async () => {
     const projectUrl = toAbsoluteUrl(`/assets/${getEnvProjectId()}/img/logo.png`);
     const ok = await isImagefileExist(projectUrl).catch(() => false);
@@ -109,7 +109,7 @@ export default function Header(props) {
             }}
           >
             <button
-              onClick={() => (window.location = returnURL + "/clear_session")}
+              onClick={locationEvent}
               style={{
                 background: "none",
                 border: 0,
@@ -138,7 +138,7 @@ export default function Header(props) {
             }}
           >
             <button
-              onClick={() => (window.location = returnURL + "/clear_session")}
+              onClick={locationEvent}
               style={{
                 background: "none",
                 border: 0,
@@ -200,7 +200,7 @@ export default function Header(props) {
       <Box className="print-hidden">
         <Button
           color="primary"
-          href={returnURL + "/clear_session"}
+          href={returnURL}
           className="btn-return-url"
           startIcon={<ArrowBackIcon></ArrowBackIcon>}
           size="medium"


### PR DESCRIPTION
address 404 error ( going to `/clear_session` only makes sense if the app is launched via FEMR) when clicking on app logo in header. 
